### PR TITLE
Update backgrid-text-cell.js for Bootstrap 3, trigger backgrid:edited

### DIFF
--- a/backgrid-text-cell.js
+++ b/backgrid-text-cell.js
@@ -116,7 +116,7 @@
 
         model.set(column.get("name"), newValue);
         this.$el.modal("hide");
-        model.trigger("backgrid:edited", model, column, newValue);
+        model.trigger("backgrid:edited", model, column, new Backgrid.Command(e));
       }
       else if (e.type != "hide") this.$el.modal("hide");
     },


### PR DESCRIPTION
Make compatible with Bootstrap 3, and make it so the modal can display a second time for the same cell by triggering the backgrid:edited event.
